### PR TITLE
Switch to HashSet

### DIFF
--- a/AlgoLongestRange/Program.cs
+++ b/AlgoLongestRange/Program.cs
@@ -15,7 +15,7 @@ namespace AlgoLongestRange
 
 		public static int[] LargestRange(int[] array)
 		{
-			Dictionary<int, bool> numbers = new Dictionary<int, bool>();
+			HashSet<int> numbers = new HashSet<int>();
 			int lowRange;
 			int highRange;
 			int[] range = new int[2];
@@ -27,26 +27,20 @@ namespace AlgoLongestRange
 			// against our left right expansion tests
 			foreach (int num in array)
 			{
-				if (numbers.ContainsKey(num))
-					continue;
-				numbers.Add(num, true);
+				numbers.Add(num);
 			}
 
 			foreach (int num in array)
 			{
-				// Mark that we've checked this number
-				if (numbers.ContainsKey(num))
-					numbers[num] = false;
-
 				lowRange = num;
-				while (numbers.ContainsKey(lowRange))
+				while (numbers.Contains(lowRange))
 				{
 					lowRange--;
 				}
 				lowRange++;
 
 				highRange = num;
-				while (numbers.ContainsKey(highRange))
+				while (numbers.Contains(highRange))
 				{
 					highRange++;
 				}


### PR DESCRIPTION
Switch to HashSet.

This has the advantage that you don't need to check for duplicate keys. As a side effect the code to mark if a number has been visited has been removed. Just look for the existence of the number in the set. Once we've hit all the numbers in the array, all the numbers in the hash would have their flag flipped anyway so it doesn't help in this case.